### PR TITLE
fix: prevent iOS startup crash from optional Fabric components

### DIFF
--- a/patches/react-native@0.85.3.patch
+++ b/patches/react-native@0.85.3.patch
@@ -1,7 +1,7 @@
-diff --git "a/C:\\Users\\microck\\AppData\\Local\\Temp\\rn-codegen-pr-patch\\orig\\scripts\\codegen\\generate-artifacts-executor\\generateRCTThirdPartyComponents.js" "b/C:\\Users\\microck\\AppData\\Local\\Temp\\rn-codegen-pr-patch\\patched\\scripts\\codegen\\generate-artifacts-executor\\generateRCTThirdPartyComponents.js"
+diff --git a/scripts/codegen/generate-artifacts-executor/generateRCTThirdPartyComponents.js b/scripts/codegen/generate-artifacts-executor/generateRCTThirdPartyComponents.js
 index 1bbfd76..95f3ec7 100644
---- "a/C:\\Users\\microck\\AppData\\Local\\Temp\\rn-codegen-pr-patch\\orig\\scripts\\codegen\\generate-artifacts-executor\\generateRCTThirdPartyComponents.js"
-+++ "b/C:\\Users\\microck\\AppData\\Local\\Temp\\rn-codegen-pr-patch\\patched\\scripts\\codegen\\generate-artifacts-executor\\generateRCTThirdPartyComponents.js"
+--- a/scripts/codegen/generate-artifacts-executor/generateRCTThirdPartyComponents.js
++++ b/scripts/codegen/generate-artifacts-executor/generateRCTThirdPartyComponents.js
 @@ -139,7 +139,7 @@ function generateRCTThirdPartyComponents(
      .flatMap(library => {
        const components = componentsInLibraries[library];
@@ -11,10 +11,10 @@ index 1bbfd76..95f3ec7 100644
        });
      })
      .join('\n');
-diff --git "a/C:\\Users\\microck\\AppData\\Local\\Temp\\rn-codegen-pr-patch\\orig\\scripts\\codegen\\templates\\RCTThirdPartyComponentsProviderMM.template" "b/C:\\Users\\microck\\AppData\\Local\\Temp\\rn-codegen-pr-patch\\patched\\scripts\\codegen\\templates\\RCTThirdPartyComponentsProviderMM.template"
+diff --git a/scripts/codegen/templates/RCTThirdPartyComponentsProviderMM.template b/scripts/codegen/templates/RCTThirdPartyComponentsProviderMM.template
 index 4ce5107..702537e 100644
---- "a/C:\\Users\\microck\\AppData\\Local\\Temp\\rn-codegen-pr-patch\\orig\\scripts\\codegen\\templates\\RCTThirdPartyComponentsProviderMM.template"
-+++ "b/C:\\Users\\microck\\AppData\\Local\\Temp\\rn-codegen-pr-patch\\patched\\scripts\\codegen\\templates\\RCTThirdPartyComponentsProviderMM.template"
+--- a/scripts/codegen/templates/RCTThirdPartyComponentsProviderMM.template
++++ b/scripts/codegen/templates/RCTThirdPartyComponentsProviderMM.template
 @@ -19,9 +19,10 @@
    static dispatch_once_t nativeComponentsToken;
  

--- a/patches/react-native@0.85.3.patch
+++ b/patches/react-native@0.85.3.patch
@@ -1,0 +1,30 @@
+diff --git "a/C:\\Users\\microck\\AppData\\Local\\Temp\\rn-codegen-pr-patch\\orig\\scripts\\codegen\\generate-artifacts-executor\\generateRCTThirdPartyComponents.js" "b/C:\\Users\\microck\\AppData\\Local\\Temp\\rn-codegen-pr-patch\\patched\\scripts\\codegen\\generate-artifacts-executor\\generateRCTThirdPartyComponents.js"
+index 1bbfd76..95f3ec7 100644
+--- "a/C:\\Users\\microck\\AppData\\Local\\Temp\\rn-codegen-pr-patch\\orig\\scripts\\codegen\\generate-artifacts-executor\\generateRCTThirdPartyComponents.js"
++++ "b/C:\\Users\\microck\\AppData\\Local\\Temp\\rn-codegen-pr-patch\\patched\\scripts\\codegen\\generate-artifacts-executor\\generateRCTThirdPartyComponents.js"
+@@ -139,7 +139,7 @@ function generateRCTThirdPartyComponents(
+     .flatMap(library => {
+       const components = componentsInLibraries[library];
+       return components.map(({componentName, className}) => {
+-        return `\t\t@"${componentName}": NSClassFromString(@"${className}"), // ${library}`;
++        return `\t\tif (Class component = NSClassFromString(@"\${className}")) {\n\t\t\tcomponents[@"\${componentName}"] = component;\n\t\t} // \${library}`;
+       });
+     })
+     .join('\n');
+diff --git "a/C:\\Users\\microck\\AppData\\Local\\Temp\\rn-codegen-pr-patch\\orig\\scripts\\codegen\\templates\\RCTThirdPartyComponentsProviderMM.template" "b/C:\\Users\\microck\\AppData\\Local\\Temp\\rn-codegen-pr-patch\\patched\\scripts\\codegen\\templates\\RCTThirdPartyComponentsProviderMM.template"
+index 4ce5107..702537e 100644
+--- "a/C:\\Users\\microck\\AppData\\Local\\Temp\\rn-codegen-pr-patch\\orig\\scripts\\codegen\\templates\\RCTThirdPartyComponentsProviderMM.template"
++++ "b/C:\\Users\\microck\\AppData\\Local\\Temp\\rn-codegen-pr-patch\\patched\\scripts\\codegen\\templates\\RCTThirdPartyComponentsProviderMM.template"
+@@ -19,9 +19,10 @@
+   static dispatch_once_t nativeComponentsToken;
+ 
+   dispatch_once(&nativeComponentsToken, ^{
+-    thirdPartyComponents = @{
++    NSMutableDictionary<NSString *, Class<RCTComponentViewProtocol>> *components =
++        [NSMutableDictionary dictionary];
+ {thirdPartyComponentsMapping}
+-    };
++    thirdPartyComponents = [components copy];
+   });
+ 
+   return thirdPartyComponents;

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -123,6 +123,7 @@ packageExtensions:
       vite: "catalog:"
 
 patchedDependencies:
+  react-native@0.85.3: patches/react-native@0.85.3.patch
   "@effect/platform-node@4.0.0-beta.102": patches/@effect__platform-node@4.0.0-beta.102.patch
   "@effect/vitest@4.0.0-beta.102": patches/@effect__vitest@4.0.0-beta.102.patch
   "@expo/metro-config@56.0.14": patches/@expo%2Fmetro-config@56.0.14.patch


### PR DESCRIPTION
## Summary

- guard each optional iOS third-party Fabric component lookup before inserting it into the generated registry
- apply the fix to the pinned React Native 0.85.3 package through the existing pnpm patch workflow

## Why

On iOS 18.6, the generated `RCTThirdPartyComponentsProvider.mm` used an NSDictionary literal containing `NSClassFromString(...)` results. When an optional component class was unavailable, inserting nil aborted the process during React Native startup with `EXC_CRASH (SIGABRT)`, before the root view rendered.

The generated registry now uses a mutable dictionary and only inserts classes that resolve successfully.

## Verification

- Rebuilt a Release device IPA from a clean generated iOS project on Xcode 26.3.
- Signed the build and launched it on BrowserStack iPhone 16 / iOS 18.6.
- The app remained foregrounded and rendered Herdr UI for 40 seconds. The only observed error was the expected failed request to a private Tailscale endpoint.